### PR TITLE
Fix HostsDeleteByIds request due to documentation

### DIFF
--- a/host.go
+++ b/host.go
@@ -145,10 +145,8 @@ func (api *API) HostsDelete(hosts Hosts) (err error) {
 // HostsDeleteByIds Wrapper for host.delete
 // https://www.zabbix.com/documentation/3.2/manual/api/reference/host/delete
 func (api *API) HostsDeleteByIds(ids []string) (err error) {
-	hostIds := make([]map[string]string, len(ids))
-	for i, id := range ids {
-		hostIds[i] = map[string]string{"hostid": id}
-	}
+	hostIds := make([]string, len(ids))
+	copy(hostIds, ids)
 
 	response, err := api.CallWithError("host.delete", hostIds)
 	if err != nil {

--- a/host.go
+++ b/host.go
@@ -145,10 +145,7 @@ func (api *API) HostsDelete(hosts Hosts) (err error) {
 // HostsDeleteByIds Wrapper for host.delete
 // https://www.zabbix.com/documentation/3.2/manual/api/reference/host/delete
 func (api *API) HostsDeleteByIds(ids []string) (err error) {
-	hostIds := make([]string, len(ids))
-	copy(hostIds, ids)
-
-	response, err := api.CallWithError("host.delete", hostIds)
+	response, err := api.CallWithError("host.delete", ids)
 	if err != nil {
 		// Zabbix 2.4 uses new syntax only
 		if e, ok := err.(*Error); ok && e.Code == -32500 {


### PR DESCRIPTION
Hello! Due to official documentation, we don't need "hostids" key. Probably it's the root cause of this issue https://github.com/claranet/terraform-provider-zabbix/issues/34

https://www.zabbix.com/documentation/6.0/en/manual/api/reference/host/delete#:~:text=%22params%22%3A,%5D%2C