### PR TITLE
Revert #11

### DIFF
--- a/host.go
+++ b/host.go
@@ -145,7 +145,12 @@ func (api *API) HostsDelete(hosts Hosts) (err error) {
 // HostsDeleteByIds Wrapper for host.delete
 // https://www.zabbix.com/documentation/3.2/manual/api/reference/host/delete
 func (api *API) HostsDeleteByIds(ids []string) (err error) {
-	response, err := api.CallWithError("host.delete", ids)
+	hostIds := make([]map[string]string, len(ids))
+	for i, id := range ids {
+		hostIds[i] = map[string]string{"hostid": id}
+	}
+
+	response, err := api.CallWithError("host.delete", hostIds)
 	if err != nil {
 		// Zabbix 2.4 uses new syntax only
 		if e, ok := err.(*Error); ok && e.Code == -32500 {


### PR DESCRIPTION
Revert claranet/go-zabbix-api#11 which broke support for old (v2.0 and older) versions of Zabbix Server.